### PR TITLE
Scrape Git repository meta data and persist to MongoDB

### DIFF
--- a/services/scraping.js
+++ b/services/scraping.js
@@ -3,7 +3,7 @@ var request = require('request');
 
 var options = {};
 //options.url = 'https://api.github.com?q=created%3A%3E2015-03-12&type=Repositories';
-options.url = 'https://api.github.com/search/repositories?q=sort=updated&order=desc';
+options.url = 'https://api.github.com/search/repositories?q=sort=updated&order=desc&page=1&per_page=53';
 options.headers = {
   'User-Agent': 'request'
 };
@@ -23,8 +23,8 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test2', function(err, db) {
 
     request(options, function(err, res, body) {
         var data = JSON.parse(body).items;
-        //console.log(data.items);
         for (var i = 0; i < data.length - 1;i++) {
+            console.log(data.length);
             metaData.insert(data[i], reportResults);
             urls.insert(formatUrl(data[i].full_name), reportResults);
         }

--- a/services/scraping.js
+++ b/services/scraping.js
@@ -1,0 +1,20 @@
+var MongoClient = require('mongodb').MongoClient;
+var request = require('request');
+
+var options = {};
+options.url = 'https://api.github.com/repositories?since=0';
+options.headers = {
+  'User-Agent': 'request'
+};
+
+MongoClient.connect('mongodb://127.0.0.1:27017/test', function(err, db) {
+    var metadata = db.collection('metadata');
+
+    request(options, function(err, res, body) {
+        var data = JSON.parse(body);
+        for (var i = 0; i < data.length;i++) {
+          metadata.insert(data[i], function(){
+          });
+        }
+    });
+});

--- a/services/scraping.js
+++ b/services/scraping.js
@@ -7,14 +7,24 @@ options.headers = {
   'User-Agent': 'request'
 };
 
-MongoClient.connect('mongodb://127.0.0.1:27017/test', function(err, db) {
-    var metadata = db.collection('metadata');
+var reportResults = function(err, result) {
+  if (err) console.log("ERROR: " + err);
+  console.log("RESULT: " + result);
+}
+
+var formatUrl = function(fullName) {
+  return {'url': 'https://github.com/' + fullName + '.git'};
+}
+
+MongoClient.connect('mongodb://127.0.0.1:27017/test2', function(err, db) {
+    var metaData = db.collection('metadata');
+    var urls = db.collection('urls');
 
     request(options, function(err, res, body) {
         var data = JSON.parse(body);
-        for (var i = 0; i < data.length;i++) {
-          metadata.insert(data[i], function(){
-          });
+        for (var i = 0; i < data.length - 1;i++) {
+            metaData.insert(data[i], reportResults);
+            urls.insert(formatUrl(data[i].full_name), reportResults);
         }
     });
 });

--- a/services/scraping.js
+++ b/services/scraping.js
@@ -2,7 +2,6 @@ var MongoClient = require('mongodb').MongoClient;
 var request = require('request');
 
 var options = {};
-//options.url = 'https://api.github.com?q=created%3A%3E2015-03-12&type=Repositories';
 options.url = 'https://api.github.com/search/repositories?q=sort=updated&order=desc&page=1&per_page=53';
 options.headers = {
   'User-Agent': 'request'
@@ -17,16 +16,13 @@ var formatUrl = function(fullName) {
   return {'url': 'https://github.com/' + fullName + '.git'};
 }
 
-MongoClient.connect('mongodb://127.0.0.1:27017/test2', function(err, db) {
+MongoClient.connect('mongodb://127.0.0.1:27017/test3', function(err, db) {
     var metaData = db.collection('metadata');
-    var urls = db.collection('urls');
 
     request(options, function(err, res, body) {
         var data = JSON.parse(body).items;
         for (var i = 0; i < data.length - 1;i++) {
-            console.log(data.length);
             metaData.insert(data[i], reportResults);
-            urls.insert(formatUrl(data[i].full_name), reportResults);
         }
     });
 });

--- a/services/scraping.js
+++ b/services/scraping.js
@@ -2,7 +2,8 @@ var MongoClient = require('mongodb').MongoClient;
 var request = require('request');
 
 var options = {};
-options.url = 'https://api.github.com/repositories?since=0';
+//options.url = 'https://api.github.com?q=created%3A%3E2015-03-12&type=Repositories';
+options.url = 'https://api.github.com/search/repositories?q=sort=updated&order=desc';
 options.headers = {
   'User-Agent': 'request'
 };
@@ -21,7 +22,8 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test2', function(err, db) {
     var urls = db.collection('urls');
 
     request(options, function(err, res, body) {
-        var data = JSON.parse(body);
+        var data = JSON.parse(body).items;
+        //console.log(data.items);
         for (var i = 0; i < data.length - 1;i++) {
             metaData.insert(data[i], reportResults);
             urls.insert(formatUrl(data[i].full_name), reportResults);


### PR DESCRIPTION
scraping.js is a service which is responsible for downloading the most recently updated git repository meta data using Git API. It then persist those repositories data to a MongoDB data store.

Notes:
The current query for this API call is:
'?q=sort=updated&order=desc&page=1&per_page=53'

-"page=1" is hardcoded currently. When we use a background process to automate running this file periodically we will have that background process be responsible for managing which page is being processed. 

-"per_page=53" is the maximum number of results per API call.
