### PR TITLE
Configure Gruntfile to run specs correctly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,6 @@
 module.exports = function(grunt) {
+
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-concat');
@@ -6,11 +8,17 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-express-server');
-  grunt.loadNpmTasks('grunt-karma');
-  grunt.loadNpmTasks('grunt-mocha');
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    mochaTest: {
+      test: {
+        options: {
+          reporter: 'spec',
+        },
+        src: ['test/**/*.js']
+      }
+    },
 
     clean: {
       dist: 'dist/*',
@@ -30,7 +38,7 @@ module.exports = function(grunt) {
         dest: 'dist/'
       }
     },
-    
+
     jshint: {
       files: [
         'Gruntfile.js',
@@ -51,27 +59,6 @@ module.exports = function(grunt) {
       }
     },
 
-    karma: {
-      options: {
-        configFile: 'karma.conf.js',
-        reporters: ['progress', 'coverage']
-      },
-      watch: {
-        background: true,
-        reporters: ['progress']
-      },
-      single: {
-        singleRun: true,
-      },
-      ci: {
-        singleRun: true,
-        coverageReporter: {
-          type: 'lcov',
-          dir: 'results/coverage/'
-        }
-      }
-    },
-
     watch: {
       gruntfile: {
         files: 'Gruntfile.js',
@@ -83,16 +70,15 @@ module.exports = function(grunt) {
         files: ['server/**'],
         tasks: ['build', 'express:dev'],
         options: {
-          spawn: false  
+          spawn: false
         }
       },
       services: {
         files: ['services/**'],
-        tasks: [ 'build','express:dev', 'karma:watch:run'],
+        tasks: [ 'build','express:dev'],
       },
       unitTests: {
-        files: ['Test/unit/parsing.js'],
-        tasks: ['karma:watch:run']
+        files: ['Test/unit/parsing.js']
       },
       integrationTests: {
 
@@ -100,19 +86,9 @@ module.exports = function(grunt) {
       e2eTests: {
 
       }
-    }
+    },
   });
-  
+
+  grunt.registerTask('test', 'mochaTest');
   grunt.registerTask('build', ['jshint', 'clean', 'copy']);
-
-  // grunt.registerTask('testClient', ['karma:single']);
-
-  grunt.registerTask('testServer', ['karma:single']);
-
-  grunt.registerTas('test', ['testServer']); //will have e2e testing later and client test later
-
-  // grunt.registerTask('ci', ['karma:ci', 'express:dev']);
-
-  grunt.registerTask('default', ['build', 'express:dev', 'karma:watch:start', 'watch']);
-
 };

--- a/package.json
+++ b/package.json
@@ -8,14 +8,8 @@
     "test": "mocha server/spec"
   },
   "devDependencies": {
-    "mocha": "^1.21.4",
     "request": "^2.34.0",
-    "chai": "^1.9.0",
-    "karma-chrome-launcher": "^0.1.4",
-    "karma-sinon": "^1.0.3",
     "grunt-contrib-copy": "^0.5.0",
-    "karma-chai": "^0.1.0",
-    "karma-mocha": "^0.1.9",
     "grunt-express-server": "^0.4.19",
     "grunt-contrib-clean": "^0.6.0",
     "chai": "^1.9.1",
@@ -26,11 +20,7 @@
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-casperjs": "^2.0.0",
-    "grunt": "^0.4.5",
-    "grunt-karma": "^0.8.3",
-    "grunt-mocha": "^0.4.11",
-    "karma": "^0.12.22",
-    "karma-coverage": "^0.2.6"
+    "grunt": "^0.4.5"
   },
   "dependencies": {
     "body-parser": "^1.12.0",

--- a/test/unit/parsing.js
+++ b/test/unit/parsing.js
@@ -1,8 +1,9 @@
+var chai = require('chai');
 var assert = chai.assert;
 var should = chai.should();
 var expect = chai.expect;
 
-describe('parsing service', function() {
+xdescribe('parsing service', function() {
   describe('parsing API Keys object', function(){
     it('should have sample keys for targeted sites', function(){
        APIKeys.should.have.property('twitter');


### PR DESCRIPTION
The line: 'grunt.registerTask('test', ['testServer'])' was causing the followng error:

  Loading "Gruntfile.js" tasks...ERROR

> > TypeError: undefined is not a function

So it has been temporarily removed

Likewise, the task involved in activating the 'watch' sub-task was also causing an error:

  Verifying property watch.client.files exists in config...ERROR

> > Unable to process task.
> >   Warning: Required config property "watch.client.files" missing.

I have also replaced the package 'grunt-mocha' with 'grunt-mocha-test' because the
former is a testing framework that is meant for frontend and the latter is meant
for backend. Since we are primarily concerned with testing services that
are being used on the backend I felt using 'grunt-mocha-test' was more
fitting package.

I have removed Karma because Karma is a test runner that is meant for
testing frontend code in psuedo-browsers, and we are focusing primarily
on testing backend services. Karma was used in the Testify sprint
for the purpose of testing client side API calls; I do not feel using
Karma in this project is justified.

I believe the best testing stack for our backend services would be
mocha, chai, and sinon. This commit contains the configurations for
integrating that testing stack with Grunt.
