### PR TITLE
Centralize database connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,9 @@
-// var db = require("./services/scraping.js");
+var MongoClient = require('mongodb').MongoClient;
 var parseService = require("./services/parsing/readFilesForParsing.js");
 var downloadService = require('./services/downloading/js_helpers/gitHubRepoGrabber.js');
 var scrapeService = require('./services/scraping.js');
 var queryService = require('./services/query.js');
 var fileSystemUtilities = require('./services/fileSystem/utilities');
-
-module.pageNumber = 1;
-
 
 var initialize = function() {
   var pathToData = __dirname + '/services/parsing/git_data';
@@ -15,7 +12,9 @@ var initialize = function() {
 };
 
 var getNextGitHubRepo = function() {
-    scrapeService.scrapeUrls(++module.pageNumber, function(){
+  MongoClient.connect('mongodb://127.0.0.1:27017/development', function(err, db) {
+    GLOBAL.db = db;
+    scrapeService.scrapeUrls(function(){
       queryService.query(function(urlList){
         downloadService.readListOfFiles(urlList, function(parseList){
           parseService.parseFile(parseList, function(){
@@ -25,6 +24,6 @@ var getNextGitHubRepo = function() {
         });
       });
     });
+  });
 };
-
 initialize();

--- a/services/downloading/download.js
+++ b/services/downloading/download.js
@@ -1,16 +1,12 @@
-var MongoClient = require('mongodb').MongoClient;
-
 var gitHubRepoGrabber = require("./js_helpers/gitHubRepoGrabber");
 var readFilesForParsing = require("./js_helpers/readFilesForParsing");
 
-MongoClient.connect('mongodb://127.0.0.1:27017/test8', function(err, db) {
-    var metaData = db.collection('metadata');
-    metaData.find({processed: false}).toArray(function(err, body) {
-      for (var i = 0;i < body.length;i++) {
-        console.log(body.git_url);
-        gitHubRepoGrabber.readListofFiles(body[i].git_url, body[i].id);
-        console.log(body[i].git_url);
-        console.log(body[i].id);
-      }
-    });
+var metaData = GLOBAL.db.collection('metadata');
+metaData.find({processed: false}).toArray(function(err, body) {
+  for (var i = 0;i < body.length;i++) {
+    console.log(body.git_url);
+    gitHubRepoGrabber.readListofFiles(body[i].git_url, body[i].id);
+    console.log(body[i].git_url);
+    console.log(body[i].id);
+  }
 });

--- a/services/parsing/readFilesForParsing.js
+++ b/services/parsing/readFilesForParsing.js
@@ -51,12 +51,9 @@ var decorateHitData = function(obj, result, pathName, regex) {
 };
 
 var storeHitData = function(data) {
-  var MongoClient = require('mongodb').MongoClient;
-  MongoClient.connect('mongodb://127.0.0.1:27017/test7', function(err, db) {
-    var hitData = db.collection('hitdata');
-    hitData.insert(data, function(err, result) {
-      console.log("HitData Persisted: " + result);
-    });
+  var hitData = GLOBAL.db.collection('hitdata');
+  hitData.insert(data, function(err, result) {
+    console.log("HitData Persisted: " + result);
   });
 };
 

--- a/services/query.js
+++ b/services/query.js
@@ -1,15 +1,12 @@
 exports.query = function(callback){
-  var MongoClient = require('mongodb').MongoClient;
   var results = [];
   function getMetaDataDocument() {
-    var db = MongoClient.connect('mongodb://127.0.0.1:27017/test8', function(err, db) {  
-      var metaData = db.collection('metadata');
-      metaData.findAndModify({processed: false}, [['_id','asc']], {$set: {processed: true}}, function(err, doc) {
-        results.push({ git_url: doc.git_url, id: doc.id});
-        handleMetaData();
-      });
-    });
-  }
+    var metaData = GLOBAL.db.collection('metadata');
+    metaData.findAndModify({processed: false}, [['_id','asc']], {$set: {processed: true}}, function(err, doc) {
+      results.push({ git_url: doc.git_url, id: doc.id});
+      handleMetaData();
+  });
+}
 
   function handleMetaData() {
     if (results.length < 2)

--- a/services/scraping.js
+++ b/services/scraping.js
@@ -1,6 +1,4 @@
-exports.scrapeUrls = function(pageNumber, callback){
-
-  var MongoClient = require('mongodb').MongoClient;
+exports.scrapeUrls = function(callback){
   var request = require('request');
 
   var options = {};
@@ -23,18 +21,14 @@ exports.scrapeUrls = function(pageNumber, callback){
   };
 
 
-  var db = MongoClient.connect('mongodb://127.0.0.1:27017/test8', 
-    function(err, db) {  
-      var metaData = db.collection('metadata');
-
-      request(options, function(err, res, body) {
-          var data = JSON.parse(body).items;
-          var dataGitUrls = [];
-          for (var i = 0; i < data.length - 1;i++) {
-            data[i].processed = false;
-            metaData.insert(data[i], reportResults);
-          }
-          callback();
-      });
+  var metaData = GLOBAL.db.collection('metadata');
+  request(options, function(err, res, body) {
+    var data = JSON.parse(body).items;
+    var dataGitUrls = [];
+    for (var i = 0; i < data.length - 1;i++) {
+      data[i].processed = false;
+      metaData.insert(data[i], reportResults);
+    }
+    callback();
   });
-};
+}


### PR DESCRIPTION
Rather than each service creating it's own database connection, each service shares a single connection.
This single connection is established in app.js and set to GLOBAL.db

Currently, the services are architectured in such a way whereby MongoDB is the first thing to be initialized.
All other services are being passed into MongoDb's connection callback function.
Basing our service architecture around callbacks is not ideal, but it is stable for our current dataload and necessary to reach MVP.
Ideally, services would use EventEmitters instead of callbacks as a means of communicating with each other asynchronously
Using EventEmitters instead of callbacks would decouple services and allow for much greater code flexability.
Until MVP is reached however, the current service architecture will be utalized.
